### PR TITLE
Fix PYTHONPATH issue

### DIFF
--- a/meta-ros-common/classes/ros_opt_prefix.bbclass
+++ b/meta-ros-common/classes/ros_opt_prefix.bbclass
@@ -31,7 +31,7 @@ inherit ${@'python3-dir' if d.getVar('ROS_PYTHON_VERSION') == '3' else 'python-d
 
 PKG_CONFIG_PATH .= ":${PKG_CONFIG_DIR}:${STAGING_DIR_HOST}${ros_libdir}/pkgconfig:${STAGING_DATADIR}/pkgconfig"
 PYTHON_SITEPACKAGES_DIR = "${ros_libdir}/${PYTHON_DIR}/site-packages"
-export PYTHONPATH:prepend = "${STAGING_DIR_NATIVE}${PYTHON_SITEPACKAGES_DIR}:"
+export PYTHONPATH = "${STAGING_DIR_NATIVE}${PYTHON_SITEPACKAGES_DIR}:"
 PYTHONPATH:class-native:prepend = "${PYTHON_SITEPACKAGES_DIR}:"
 
 FILES_SOLIBSDEV += " ${ros_libdir}/lib*${SOLIBSDEV}"


### PR DESCRIPTION
Remove override code of PYTHONPATH which makes PYTHONPATH is not available in build job.
```
| ModuleNotFoundError: No module named 'ament_package'
| CMake Error at ament_cmake_package_templates-extras.cmake:41 (message):
```
PYTHONPATH is not found in run.do_configure.